### PR TITLE
rename theme values and use aliases were possible

### DIFF
--- a/src/TableDownloadButton/TableDownloadButton.styles.ts
+++ b/src/TableDownloadButton/TableDownloadButton.styles.ts
@@ -13,19 +13,19 @@ export const TableActionButton = styled.button<Props>`
   ${p =>
     p.variant === 'primary' &&
     css`
-      border: 2px solid ${p.theme.colors.skyBlue};
-      background-color: ${p.theme.colors.skyBlue};
+      border: 2px solid ${p.theme.colors.aliases.primary};
+      background-color: ${p.theme.colors.aliases.primary};
       outline: none;
       &:hover {
-        background-color: ${p.theme.colors.lightSkyBlue};
-        border: 2px solid ${p.theme.colors.lightSkyBlue};
+        background-color: ${p.theme.colors.aliases.primaryLight};
+        border: 2px solid ${p.theme.colors.aliases.primaryLight};
       }
       &:focus {
-        background-color: ${p.theme.colors.lightSkyBlue};
-        border: 2px solid ${p.theme.colors.darkSkyBlue};
+        background-color: ${p.theme.colors.aliases.primaryLight};
+        border: 2px solid ${p.theme.colors.aliases.primaryDark};
       }
       &:active {
-        background-color: ${p.theme.colors.darkSkyBlue};
+        background-color: ${p.theme.colors.aliases.primaryDark};
       }
       &:disabled {
         background-color: ${p.theme.colors.gray3};

--- a/src/defaultTheme.ts
+++ b/src/defaultTheme.ts
@@ -1,31 +1,37 @@
 import { DefaultTheme } from 'styled-components';
 
 const colors = {
+  // Sky blue
+  skyBlueLighter: '#B4EEF9',
+  skyBlueLight: '#1DCEEC',
   skyBlue: '#00B8D7',
-  green: '#99C875',
+  skyBlueDark: '#019FBA',
+  skyBlueDarker: '#00859C',
+  // Red
+  redLighter: '#FCE8E8',
+  redLight: '#FFC0C0',
   red: '#DB0010',
-  steelBlue: '#E5EEFE',
+  // Misc
   white: '#FFFFFF',
   black: '#212529',
-  lighterSkyBlue: '#B4EEF9',
-  lightSkyBlue: '#1DCEEC',
-  darkSkyBlue: '#019FBA',
-  darkerSkyBlue: '#00859C',
-  lighterGreen: '#C8EAAF',
-  lightGreen: '#A0D777',
-  darkGreen: '#8AB26B',
-  darkerGreen: '#75985B',
+  // Green
+  greenLighter: '#C8EAAF',
+  greenLight: '#A0D777',
+  green: '#99C875',
+  greenDark: '#8AB26B',
+  greenDarker: '#75985B',
+  // Gray
   gray1: '#F6F6F6',
   gray2: '#F2F2F2',
   gray3: '#D5D7DC',
   gray4: '#717171',
   gray5: '#4C4C4C',
-  lighterSteelBlue: '#F7FAFC',
-  lightSteelBlue: '#F1F5FD',
-  darkSteelBlue: '#ABB8C5',
-  darkerSteelBlue: '#818E9B',
-  lightRed: '#FFC0C0',
-  lighterRed: '#FCE8E8',
+  // Steel blue
+  steelBlueLighter: '#F7FAFC',
+  steelBlueLight: '#F1F5FD',
+  steelBlue: '#E5EEFE',
+  steelBlueDark: '#ABB8C5',
+  steelBlueDarker: '#818E9B',
 };
 
 const font = {
@@ -60,11 +66,11 @@ const defaultTheme: DefaultTheme = {
     ...colors,
     aliases: {
       primary: colors.skyBlue,
-      primaryLight: colors.lightSkyBlue,
-      primaryDark: colors.darkSkyBlue,
+      primaryLight: colors.skyBlueLight,
+      primaryDark: colors.skyBlueDark,
       secondary: colors.green,
-      secondaryLight: colors.lightGreen,
-      secondaryDark: colors.darkGreen,
+      secondaryLight: colors.greenLight,
+      secondaryDark: colors.greenDark,
     },
   },
   font,

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -21,38 +21,44 @@ declare module 'styled-components' {
     boxShadow: SizeHelper;
     colors: {
       aliases: {
-        primary: string;
         primaryLight: string;
+        primary: string;
         primaryDark: string;
-        secondary: string;
         secondaryLight: string;
+        secondary: string;
         secondaryDark: string;
       };
+      // Sky blue
+      skyBlueLighter: string;
+      skyBlueLight: string;
       skyBlue: string;
-      green: string;
+      skyBlueDark: string;
+      skyBlueDarker: string;
+      // Red
+      redLighter: string;
+      redLight: string;
       red: string;
-      steelBlue: string;
+      // Misc
       white: string;
       black: string;
-      lighterSkyBlue: string;
-      lightSkyBlue: string;
-      darkSkyBlue: string;
-      darkerSkyBlue: string;
-      lighterGreen: string;
-      lightGreen: string;
-      darkGreen: string;
-      darkerGreen: string;
+      // Green
+      greenLighter: string;
+      greenLight: string;
+      green: string;
+      greenDark: string;
+      greenDarker: string;
+      // Gray
       gray1: string;
       gray2: string;
       gray3: string;
       gray4: string;
       gray5: string;
-      lighterSteelBlue: string;
-      lightSteelBlue: string;
-      darkSteelBlue: string;
-      darkerSteelBlue: string;
-      lightRed: string;
-      lighterRed: string;
+      // Steel blue
+      steelBlueLighter: string;
+      steelBlueLight: string;
+      steelBlue: string;
+      steelBlueDark: string;
+      steelBlueDarker: string;
     };
     font: {
       family: {


### PR DESCRIPTION
Ticket: no ticket

Why this is needed: @zac-robinson I changed the naming of the theme values slightly, I feel that it reads better to have the colour first and the darkness/lightness of that colour after. I think it makes it easier to scan with your eyes and makes the typescript auto-completion easier. What are your thoughts?

Link to Figma doc: no design
