### PR TITLE
Remove focus outline

### DIFF
--- a/src/TableDownloadButton/TableDownloadButton.styles.ts
+++ b/src/TableDownloadButton/TableDownloadButton.styles.ts
@@ -23,6 +23,7 @@ export const TableActionButton = styled.button<Props>`
       &:focus {
         background-color: ${p.theme.colors.aliases.primaryLight};
         border: 2px solid ${p.theme.colors.aliases.primaryDark};
+        outline: none;
       }
       &:active {
         background-color: ${p.theme.colors.aliases.primaryDark};


### PR DESCRIPTION
Ticket:

Why this is needed: remove focus outline on table button focus

Link to Figma doc:
