### PR TITLE
bump to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",


### PR DESCRIPTION
Ticket: nope

Why this is needed: Becuase Martin forgot to bump the version in last PR

Link to Figma doc: nope
