### PR TITLE
Make string comparison not object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/DropDown/DropDown.tsx
+++ b/src/DropDown/DropDown.tsx
@@ -44,7 +44,7 @@ export const DropDown = (props: Props): JSX.Element => (
               {props.items.map((item: Item, index: number) => (
                 <StyledListItem
                   highlighted={index === highlightedIndex}
-                  selectedItem={item === selectedItem}
+                  selectedItem={item.value === selectedItem.value}
                   {...getItemProps({
                     item,
                     key: item.value,


### PR DESCRIPTION
Ticket:

Why this is needed: This is to make the selected highlight work all the time.

Link to Figma doc:
