### PR TITLE
add margin to bottom of dropdown to avoid clashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/DropDown/DropDown.styles.ts
+++ b/src/DropDown/DropDown.styles.ts
@@ -44,6 +44,7 @@ export const StyledList = styled.ul`
   background: ${p => p.theme.colors.white};
   box-shadow: ${p => p.theme.boxShadow.standard};
   margin-top: ${p => p.theme.spacing.xsmall};
+  margin-bottom: ${p => p.theme.spacing.xsmall};
   border-radius: ${p => p.theme.borderRadius.standard};
   &:after {
     content: '';


### PR DESCRIPTION
Ticket: part of https://edozohq.atlassian.net/browse/ED-3362

Why this is needed: allow the shadow to be displayed on dropdown

Link to Figma doc:
