### PR TITLE
some vomm tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/PriceIndicator/PriceIndicator.stories.mdx
+++ b/src/PriceIndicator/PriceIndicator.stories.mdx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import { PriceIndicator } from '../PriceIndicator';
 import { Switch } from '../Switch';
+import { Tooltip } from '../Tooltip';
 
 <Meta title="Components|PriceIndicator" />
 
@@ -53,7 +54,11 @@ PriceIndicator is a simple styled and animated set of elements to be use to indi
           <button onClick={() => updatePrice({ priceIncrease: Math.random() })}>Increase price by random penny's</button>
           <div style={{ position: 'absolute', bottom: '24px', right: '24px' }}>
             <PriceIndicator isActive total={priceTotal} addition={priceIncrease}>
-              hover content will be here and it can be super long
+              <Tooltip content={<div>
+                <span>Tooltip</span>
+              </div>}>
+                <button type="button">the child</button>
+              </Tooltip>hover content will be here and it can be super long
             </PriceIndicator>
           </div>
         </div>

--- a/src/PriceIndicator/PriceIndicator.styles.ts
+++ b/src/PriceIndicator/PriceIndicator.styles.ts
@@ -33,7 +33,7 @@ export const PriceUpdateIndicator = styled(motion.div)`
 `;
 
 export const HoverContainer = styled(motion.div)`
-  background: ${p => p.theme.colors.grayLight};
+  background: ${p => p.theme.colors.white};
   z-index: 0;
   height: 32px;
   display: flex;
@@ -59,7 +59,7 @@ export const TotalPrice = styled.div<{ isActive: boolean }>`
   height: 32px;
   padding: 0 ${p => p.theme.spacing.xsmall};
   border-radius: ${p => p.theme.borderRadius.standard};
-  background: ${p => p.theme.colors.grayLight};
+  background: ${p => p.theme.colors.white};
   color: ${p => (p.isActive ? p.theme.colors.aliases.primary : p.theme.colors.grayDarker)};
   font-family: ${p => p.theme.font.family.main};
   font-size: ${p => p.theme.font.size.label};

--- a/src/PriceIndicator/PriceIndicator.tsx
+++ b/src/PriceIndicator/PriceIndicator.tsx
@@ -11,7 +11,13 @@ const updaterVariants = {
 
 const hoverContentVariants = {
   rest: { x: 500 },
-  hover: { x: 3, transition: { duration: 0.4, ease: 'easeIn' } },
+  hover: {
+    x: 0,
+    transitionEnd: {
+      overflow: 'visible',
+    },
+    transition: { duration: 0.4, ease: 'easeIn' },
+  },
 };
 
 const hoverDividerVariants = {

--- a/src/Typography/Typography.styles.ts
+++ b/src/Typography/Typography.styles.ts
@@ -58,6 +58,7 @@ export const StyledBody = styled.p`
   font-size: ${p => p.theme.font.size.body};
   line-height: ${p => p.theme.font.lineHeight.body};
   font-weight: ${p => p.theme.font.weight.regular};
+  display: inline-block;
 `;
 
 export const StyledBodySmall = styled.p`
@@ -65,6 +66,7 @@ export const StyledBodySmall = styled.p`
   font-size: ${p => p.theme.font.size.bodySmall};
   line-height: ${p => p.theme.font.lineHeight.bodySmall};
   font-weight: ${p => p.theme.font.weight.regular};
+  display: inline-block;
 `;
 
 export const StyledLabel = styled.p`
@@ -72,6 +74,7 @@ export const StyledLabel = styled.p`
   font-size: ${p => p.theme.font.size.label};
   line-height: ${p => p.theme.font.lineHeight.label};
   font-weight: ${p => p.theme.font.weight.regular};
+  display: inline-block;
 `;
 
 export const StyledSmall = styled.p`
@@ -79,6 +82,7 @@ export const StyledSmall = styled.p`
   font-size: ${p => p.theme.font.size.small};
   line-height: ${p => p.theme.font.lineHeight.small};
   font-weight: ${p => p.theme.font.weight.semibold};
+  display: inline-block;
 `;
 
 export const DisplayWrapper = styled.div`


### PR DESCRIPTION
BEFORE CREATING THIS PR, have you bumped the package JSON where appropriate? yup

Ticket / Why this is needed:
The main change needed is the `transitionEnd` in the pricing indicator, this will mean that the tooltip can be visible while keeping the hover animation as it is.

The other changes are things that I noticed were wrong. The display inline-block is so that those components don't require a new line (by default). And the color of the pricing indicator was wrong.

Link to Figma doc: no
