### PR TITLE
making price indicator work with tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/PriceIndicator/PriceIndicator.stories.mdx
+++ b/src/PriceIndicator/PriceIndicator.stories.mdx
@@ -54,7 +54,7 @@ PriceIndicator is a simple styled and animated set of elements to be use to indi
           <button onClick={() => updatePrice({ priceIncrease: Math.random() })}>Increase price by random penny's</button>
           <div style={{ position: 'absolute', bottom: '24px', right: '24px' }}>
             <PriceIndicator isActive total={priceTotal} addition={priceIncrease}>
-              <Tooltip content={<div>
+              <Tooltip trigger="click" offset={[0, 16]} placement="top-start" interactive={true} interactiveBorder={30} content={<div>
                 <span>Tooltip</span>
               </div>}>
                 <button type="button">the child</button>

--- a/src/PriceIndicator/PriceIndicator.styles.ts
+++ b/src/PriceIndicator/PriceIndicator.styles.ts
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 
+export const StylePricingContainer = styled.div`
+  transform: translateY(${p => p.theme.spacing.small});
+`;
+
 export const PriceTotalWrapper = styled(motion.div)`
   display: inline-flex;
   justify-content: flex-end;
@@ -51,14 +55,18 @@ export const Divider = styled(motion.div)`
   left: 0;
 `;
 
-export const TotalPrice = styled.div<{ isActive: boolean }>`
+export const TotalPrice = styled.div<{ isActive: boolean; isPriceHover: boolean }>`
   display: inline-flex;
   position: relative;
   justify-content: center;
   align-items: center;
   height: 32px;
+  margin-top: ${p => p.theme.spacing.small};
+  margin-bottom: ${p => p.theme.spacing.small};
   padding: 0 ${p => p.theme.spacing.xsmall};
   border-radius: ${p => p.theme.borderRadius.standard};
+  border-top-left-radius: ${p => (p.isPriceHover ? '0px' : p.theme.borderRadius.standard)};
+  border-bottom-left-radius: ${p => (p.isPriceHover ? '0px' : p.theme.borderRadius.standard)};
   background: ${p => p.theme.colors.white};
   color: ${p => (p.isActive ? p.theme.colors.aliases.primary : p.theme.colors.grayDarker)};
   font-family: ${p => p.theme.font.family.main};

--- a/src/PriceIndicator/PriceIndicator.styles.ts
+++ b/src/PriceIndicator/PriceIndicator.styles.ts
@@ -55,7 +55,7 @@ export const Divider = styled(motion.div)`
   left: 0;
 `;
 
-export const TotalPrice = styled.div<{ isActive: boolean; isPriceHover: boolean }>`
+export const TotalPrice = styled.div<{ isActive: boolean; isPriceHovered: boolean }>`
   display: inline-flex;
   position: relative;
   justify-content: center;
@@ -65,8 +65,8 @@ export const TotalPrice = styled.div<{ isActive: boolean; isPriceHover: boolean 
   margin-bottom: ${p => p.theme.spacing.small};
   padding: 0 ${p => p.theme.spacing.xsmall};
   border-radius: ${p => p.theme.borderRadius.standard};
-  border-top-left-radius: ${p => (p.isPriceHover ? '0px' : p.theme.borderRadius.standard)};
-  border-bottom-left-radius: ${p => (p.isPriceHover ? '0px' : p.theme.borderRadius.standard)};
+  border-top-left-radius: ${p => (p.isPriceHovered ? '0px' : p.theme.borderRadius.standard)};
+  border-bottom-left-radius: ${p => (p.isPriceHovered ? '0px' : p.theme.borderRadius.standard)};
   background: ${p => p.theme.colors.white};
   color: ${p => (p.isActive ? p.theme.colors.aliases.primary : p.theme.colors.grayDarker)};
   font-family: ${p => p.theme.font.family.main};

--- a/src/PriceIndicator/PriceIndicator.tsx
+++ b/src/PriceIndicator/PriceIndicator.tsx
@@ -40,7 +40,7 @@ export interface Props {
 
 export const PriceIndicator: React.FC<Props> = ({ total, addition, isActive = false, children }) => {
   const [isAdditionVisible, setIsAdditionVisible] = useState(false);
-  const [isPriceHover, setIsPriceHover] = useState(false);
+  const [isPriceHovered, setIsPriceHovered] = useState(false);
 
   const formattedTotal = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(total);
   const formattedAddition = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(addition);
@@ -61,15 +61,15 @@ export const PriceIndicator: React.FC<Props> = ({ total, addition, isActive = fa
           </PriceUpdateIndicator>
         )}
       </AnimatePresence>
-      <PriceTotalWrapper onHoverStart={() => setIsPriceHover(true)} onHoverEnd={() => setIsPriceHover(false)}>
-        {isPriceHover && (
+      <PriceTotalWrapper onHoverStart={() => setIsPriceHovered(true)} onHoverEnd={() => setIsPriceHovered(false)}>
+        {isPriceHovered && (
           <HoverContainer initial="rest" animate="hover" exit="rest" variants={hoverContentVariants}>
             {children}
           </HoverContainer>
         )}
 
-        <TotalPrice isActive={isActive} isPriceHover={isPriceHover}>
-          {isPriceHover && <Divider initial="rest" animate="hover" exit="rest" variants={hoverDividerVariants} />}
+        <TotalPrice isActive={isActive} isPriceHovered={isPriceHovered}>
+          {isPriceHovered && <Divider initial="rest" animate="hover" exit="rest" variants={hoverDividerVariants} />}
           {formattedTotal}
         </TotalPrice>
       </PriceTotalWrapper>

--- a/src/PriceIndicator/PriceIndicator.tsx
+++ b/src/PriceIndicator/PriceIndicator.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { useEffectAfterMount } from '../hooks';
-import { PriceUpdateIndicator, PriceTotalWrapper, HoverContainer, TotalPrice, Divider } from './PriceIndicator.styles';
+import {
+  PriceUpdateIndicator,
+  PriceTotalWrapper,
+  HoverContainer,
+  TotalPrice,
+  Divider,
+  StylePricingContainer,
+} from './PriceIndicator.styles';
 
 const updaterVariants = {
   initial: { opacity: 0, x: -50 },
@@ -46,7 +53,7 @@ export const PriceIndicator: React.FC<Props> = ({ total, addition, isActive = fa
   }, [formattedAddition]);
 
   return (
-    <React.Fragment>
+    <StylePricingContainer>
       <AnimatePresence>
         {isAdditionVisible && (
           <PriceUpdateIndicator variants={updaterVariants} initial="initial" animate="animate" exit="exit">
@@ -60,11 +67,12 @@ export const PriceIndicator: React.FC<Props> = ({ total, addition, isActive = fa
             {children}
           </HoverContainer>
         )}
-        <TotalPrice isActive={isActive} style={{ zIndex: 2 }}>
+
+        <TotalPrice isActive={isActive} isPriceHover={isPriceHover}>
           {isPriceHover && <Divider initial="rest" animate="hover" exit="rest" variants={hoverDividerVariants} />}
           {formattedTotal}
         </TotalPrice>
       </PriceTotalWrapper>
-    </React.Fragment>
+    </StylePricingContainer>
   );
 };

--- a/src/Tooltip/Tooltip.stories.mdx
+++ b/src/Tooltip/Tooltip.stories.mdx
@@ -24,7 +24,7 @@ A tooltip component to display information on hover
 <Preview>
   <Story name="Interactive">
     <div style={{minHeight: "50vh"}}>
-      <Tooltip interactive={true} interactiveBorder={10} content={<div>
+      <Tooltip interactive interactiveBorder={10} content={<div>
         <span>Tooltip</span>
         <button type="button">content</button>
       </div>}>


### PR DESCRIPTION
BEFORE CREATING THIS PR, have you bumped the package JSON where appropriate? Yup

Ticket / Why this is needed: The overflow settings on the price indicator would not allow the tooltip to work, and the tooltip being outside its container meant a buffer had to be built in too.

Link to Figma doc: https://www.figma.com/file/sUsVhNqXyq8zfVgT6n7qbR/Voom-Maps?node-id=235%3A470

