### PR TITLE
Move header and logo to gen-pop and fix list css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "0.15.19",
+  "version": "0.16.0",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/EdozoLogo/EdozoLogo.stories.tsx
+++ b/src/EdozoLogo/EdozoLogo.stories.tsx
@@ -3,7 +3,7 @@ import { Story, Meta } from '@storybook/react';
 import { EdozoLogo } from './EdozoLogo';
 
 export default {
-  title: 'OccupierPlans/EdozoLogo',
+  title: 'Components/EdozoLogo',
   component: EdozoLogo,
 } as Meta;
 

--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -9,7 +9,7 @@ import { Popover } from '../Popover';
 import { List, ListItem } from '../List';
 
 export default {
-  title: 'OccupierPlans/Header',
+  title: 'Components/Header',
   component: Header,
 } as Meta;
 

--- a/src/List/List.stories.tsx
+++ b/src/List/List.stories.tsx
@@ -38,3 +38,9 @@ export const DefaultList: Story = args => (
     <DisabledListItem {...DisabledListItem.args} />
   </List>
 );
+
+export const SingleItemList: Story = args => (
+  <List {...args}>
+    <ControlledListItem {...ControlledListItem.args} />
+  </List>
+);

--- a/src/List/List.styles.ts
+++ b/src/List/List.styles.ts
@@ -5,14 +5,13 @@ export interface StyleProps {
 }
 
 export const StyledList = styled.div<StyleProps>`
-  border-radius: ${p => p.theme.borderRadius[p.radius || 'standard']};
   background-color: ${p => p.theme.colors.white};
-  > :first-child {
-    border-radius: ${p => p.theme.borderRadius[p.radius || 'standard']}
-      ${p => p.theme.borderRadius[p.radius || 'standard']} 0 0;
+  border-radius: ${p => p.theme.borderRadius[p.radius || 'standard']};
+  > div {
+    border-radius: ${p => p.theme.borderRadius[p.radius || 'standard']};
   }
-  > :last-child {
-    border-radius: 0 0 ${p => p.theme.borderRadius[p.radius || 'standard']}
-      ${p => p.theme.borderRadius[p.radius || 'standard']};
+
+  :not(:first-child) {
+    border-radius: 0;
   }
 `;


### PR DESCRIPTION
BEFORE CREATING THIS PR, have you bumped the package JSON where appropriate? Yup bumped it to 0.16.0 to reflect the header being ready for another app

Ticket / Why this is needed: Move header and logo out of the occupier plans section.

 Also fix a think on the list that has been really annoying me. If you only had one item in the list the border-radius didn't work. This fix won't work 100% on IE!! but the list will still be functional, this is due to using :not() https://caniuse.com/?search=%3Anot()
