### PR TITLE
fix new line selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/Icons/icons/new-line-tool.svg
+++ b/src/Icons/icons/new-line-tool.svg
@@ -1,1 +1,3 @@
-<svg viewBox="0 0 25 25" fill="#4C4C4C" xmlns="http://www.w3.org/2000/svg"><path stroke="#4C4C4C" stroke-width="1.6" d="m.566 1.434 23 23"/></svg>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.000244141 1.02836L1.02861 0L23.7892 22.7585L22.7564 23.7869L0.000244141 1.02836Z"/>
+</svg>


### PR DESCRIPTION
BEFORE CREATING THIS PR, have you bumped the package JSON where appropriate? 
yup

Ticket / Why this is needed: nope

Link to Figma doc:
nope

I have changed the svg file for new line tool to be a shape with a fill 
rather than a line/path with a stroke - this means it will allow the 
selection colour to come through in the maps app - currently it doesn't go 
blue when selected.
