### PR TITLE
prep some components for react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/EmptyState/EmptyState.stories.tsx
+++ b/src/EmptyState/EmptyState.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { Fragment } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { StackIcon } from '../Icons';

--- a/src/Error/usage/NotFound.tsx
+++ b/src/Error/usage/NotFound.tsx
@@ -4,7 +4,11 @@ import { Ring } from '../Ring';
 import { ErrorColumn } from '../ErrorColumn';
 import { ErrorInfo } from '../ErrorInfo';
 
-export const NotFound: React.FC = ({
+interface Props {
+  children: React.ReactNode;
+}
+
+export const NotFound: React.FC<Props> = ({
   children = "This page doesn't exist or is no longer available, please go back home.",
 }) => (
   <Fragment>

--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { Fragment } from 'react';
 import { Story, Meta } from '@storybook/react';

--- a/src/Header/Menu/Menu.tsx
+++ b/src/Header/Menu/Menu.tsx
@@ -3,15 +3,19 @@ import { PlatformMenuButtonProps } from '../PlatformMenu/PlatformButton.styles';
 import { PlatformButton } from '../PlatformMenu/PlatformButton';
 import { PlatformMenu } from '../PlatformMenu';
 import { StyledMenu } from './Menu.styles';
-import { MenuItem } from './MenuItem';
+import { MenuItem, MenuItemProps } from './MenuItem';
 
 interface MenuComposition {
-  Item: React.FC;
+  Item: React.FC<MenuItemProps>;
   PlatformMenu: React.FC;
   PlatformButton: React.FC<PlatformMenuButtonProps>;
 }
 
-const Menu: React.FC & MenuComposition = ({ children }) => {
+interface Props {
+  children: React.ReactNode;
+}
+
+const Menu: React.FC<Props> & MenuComposition = ({ children }) => {
   return <StyledMenu>{children}</StyledMenu>;
 };
 

--- a/src/Header/Menu/MenuItem.tsx
+++ b/src/Header/Menu/MenuItem.tsx
@@ -1,8 +1,12 @@
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import { useHeaderContext } from '../Header';
 import { StyledMenuItem } from './MenuItem.styles';
 
-export const MenuItem: React.FC<HTMLAttributes<HTMLDivElement>> = ({ children }) => {
+export interface MenuItemProps {
+  children: React.ReactNode;
+}
+
+export const MenuItem: React.FC<MenuItemProps> = ({ children }) => {
   const { appName } = useHeaderContext();
 
   return <StyledMenuItem appName={appName}>{children}</StyledMenuItem>;

--- a/src/InputGroup/InputGroup.stories.tsx
+++ b/src/InputGroup/InputGroup.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { TextSmall } from '../Typography';

--- a/src/Popover/Popover.stories.tsx
+++ b/src/Popover/Popover.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { Popover } from './Popover';

--- a/src/Typography/Typography.tsx
+++ b/src/Typography/Typography.tsx
@@ -16,19 +16,23 @@ import {
   StyledSubTitle,
 } from './Typography.styles';
 
-export const H1: React.FC = props => <StyledH1 {...props}>{props.children}</StyledH1>;
-export const H2: React.FC = props => <StyledH2 {...props}>{props.children}</StyledH2>;
-export const H3: React.FC = props => <StyledH3 {...props}>{props.children}</StyledH3>;
-export const H4: React.FC = props => <StyledH4 {...props}>{props.children}</StyledH4>;
-export const H5: React.FC = props => <StyledH5 {...props}>{props.children}</StyledH5>;
-export const H6: React.FC = props => <StyledH6 {...props}>{props.children}</StyledH6>;
+export interface Props {
+  children: React.ReactNode;
+}
 
-export const TextXLarge: React.FC = props => <StyledTextXLarge {...props}>{props.children}</StyledTextXLarge>;
-export const TextLarge: React.FC = props => <StyledTextLarge {...props}>{props.children}</StyledTextLarge>;
-export const TextBase: React.FC = props => <StyledTextBase {...props}>{props.children}</StyledTextBase>;
-export const TextSmall: React.FC = props => <StyledTextSmall {...props}>{props.children}</StyledTextSmall>;
-export const TextXSmall: React.FC = props => <StyledTextXSmall {...props}>{props.children}</StyledTextXSmall>;
-export const TextXXSmall: React.FC = props => <StyledTextXXSmall {...props}>{props.children}</StyledTextXXSmall>;
+export const H1: React.FC<Props> = props => <StyledH1 {...props}>{props.children}</StyledH1>;
+export const H2: React.FC<Props> = props => <StyledH2 {...props}>{props.children}</StyledH2>;
+export const H3: React.FC<Props> = props => <StyledH3 {...props}>{props.children}</StyledH3>;
+export const H4: React.FC<Props> = props => <StyledH4 {...props}>{props.children}</StyledH4>;
+export const H5: React.FC<Props> = props => <StyledH5 {...props}>{props.children}</StyledH5>;
+export const H6: React.FC<Props> = props => <StyledH6 {...props}>{props.children}</StyledH6>;
 
-export const Title: React.FC = props => <StyledTitle {...props}>{props.children}</StyledTitle>;
-export const SubTitle: React.FC = props => <StyledSubTitle {...props}>{props.children}</StyledSubTitle>;
+export const TextXLarge: React.FC<Props> = props => <StyledTextXLarge {...props}>{props.children}</StyledTextXLarge>;
+export const TextLarge: React.FC<Props> = props => <StyledTextLarge {...props}>{props.children}</StyledTextLarge>;
+export const TextBase: React.FC<Props> = props => <StyledTextBase {...props}>{props.children}</StyledTextBase>;
+export const TextSmall: React.FC<Props> = props => <StyledTextSmall {...props}>{props.children}</StyledTextSmall>;
+export const TextXSmall: React.FC<Props> = props => <StyledTextXSmall {...props}>{props.children}</StyledTextXSmall>;
+export const TextXXSmall: React.FC<Props> = props => <StyledTextXXSmall {...props}>{props.children}</StyledTextXXSmall>;
+
+export const Title: React.FC<Props> = props => <StyledTitle {...props}>{props.children}</StyledTitle>;
+export const SubTitle: React.FC<Props> = props => <StyledSubTitle {...props}>{props.children}</StyledSubTitle>;


### PR DESCRIPTION
BEFORE CREATING THIS PR, have you bumped the package JSON where 
appropriate? Y

Ticket / Why this is needed:
No ticket

Link to Figma doc:
No Figma doc

Reason for this PR:
React 18 no longer includes children in the type `React.FC`, this PR will 
pass children explicitly for some components (required in dashboard), this 
will not effect older versions of react (the versions we use) as the 
explicit passing will override the implicit.
