### PR TITLE
Remove attr from pseudo element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mechanical-wombat",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/Switch/Switch.styles.ts
+++ b/src/Switch/Switch.styles.ts
@@ -19,8 +19,8 @@ export const ToggleInner = styled.span<Partial<Props>>`
   width: 200%;
   margin-left: -100%;
   transition: margin 0.3s ease-in 0s;
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     display: inline-flex;
     float: left;
     width: 50%;
@@ -33,8 +33,8 @@ export const ToggleInner = styled.span<Partial<Props>>`
     align-items: center;
     justify-content: center;
   }
-  &:before {
-    content: attr(data-yes);
+  &::before {
+    content: '';
     text-transform: uppercase;
     padding-left: 6px;
     padding-right: 24px;
@@ -42,8 +42,8 @@ export const ToggleInner = styled.span<Partial<Props>>`
     color: #fff;
   }
 
-  :after {
-    content: attr(data-no);
+  &::after {
+    content: '';
     text-transform: uppercase;
     padding-right: 6px;
     padding-left: 24px;
@@ -87,7 +87,7 @@ export const Toggle = styled.span<Partial<Props>>`
     css`
       background-color: #ccc;
       cursor: not-allowed;
-      &:before {
+      &::before {
         background-color: #ccc;
         cursor: not-allowed;
       }


### PR DESCRIPTION
Chrome have been doing some updates to how `attr` works [here](https://developer.chrome.com/blog/advanced-attr) looking to improve it form the looks of it. But it looks like the way we have written our switch has been a casualty (I think this is unintentional on their part).

The crux of it is, it doesn't look like having the `attr` inside the `content` css property is required for our switches to work, so I have taken it out. Worth noting that `content` is required on `::before` and `::after` pseudo elements.

I've also updated these pseudo elements to use the more correct syntax (either will work `:` or `::`) but we should stick with the intended use were possible. 