### PR TITLE
Handle SVG image imports as base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edozo/mechanical-wombat",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'tsup';
 import svgr from 'esbuild-plugin-svgr';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 export default defineConfig({
   entry: ['src/index.tsx'],
@@ -15,9 +17,32 @@ export default defineConfig({
   target: 'es2020',
   shims: false,
   loader: {
-    '.svg': 'tsx',
+    '.svg': 'file',
   },
   esbuildPlugins: [
+    // Custom plugin to handle ?url imports
+    {
+      name: 'svg-url-loader',
+      setup(build) {
+        build.onResolve({ filter: /\.svg\?url$/ }, args => ({
+          path: args.path.replace('?url', ''),
+          namespace: 'svg-url',
+        }));
+
+        build.onLoad({ filter: /.*/, namespace: 'svg-url' }, args => {
+          const sourceSvgPath = args.path.replace('./icons/', 'src/Icons/icons/');
+          const fullSvgPath = resolve(process.cwd(), sourceSvgPath);
+
+          try {
+            const svgContent = readFileSync(fullSvgPath, 'utf8');
+            const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svgContent).toString('base64')}`;
+            return { contents: `export default "${dataUrl}";`, loader: 'js' };
+          } catch {
+            return { contents: `export default "";`, loader: 'js' };
+          }
+        });
+      },
+    },
     svgr({
       exportType: 'default',
       typescript: true,


### PR DESCRIPTION
Version 2.0.11

Handle SVG URL imports as base64 - this will cover our use case for having these imports, which is only for the context menu.