### PR TITLE
Update header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v3.0.0
+- Update `AppHeader` to:
+  - Display the Products drop down when users isn't authenticated
+  - Accept only a `url` instead of both a `stageUrl` and `prodUrl`. Users are required to derive their url within their own apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,4 @@
 
 ## v3.0.0
 - Update `AppHeader` to:
-  - Display the Products drop down when users isn't authenticated
   - Accept only a `url` instead of both a `stageUrl` and `prodUrl`. Users are required to derive their url within their own apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edozo/mechanical-wombat",
-  "version": "2.0.11",
+  "version": "3.0.0",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/Header/AppHeader.tsx
+++ b/src/Header/AppHeader.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { ProductSwitch } from './ProductSwitch';
 import { LogoutIcon } from '../Icons';
 import { Menu } from './Menu';
-import { Context, Header } from './Header';
+import { AppName, Context, Header } from './Header';
 
 export interface ProductInfo {
-  appName: string;
+  appName: AppName;
   description: string;
-  productionUrl: string;
-  stageUrl: string;
+  url: string;
   disabled?: boolean;
 }
 
@@ -16,26 +15,22 @@ const defaultProducts: ProductInfo[] = [
   {
     appName: 'maps',
     description: 'Create best in class OS mapping with single click technology',
-    productionUrl: 'https://maps.edozo.com/',
-    stageUrl: 'https://dev-maps.edozo.co/',
+    url: 'https://maps.edozo.com/',
   },
   {
     appName: 'occupiers',
     description: 'Create plans and see occupiers for all use classes',
-    productionUrl: 'https://occupiers.edozo.com/',
-    stageUrl: 'https://occupiers.edozo.co/',
+    url: 'https://occupiers.edozo.com/',
   },
   {
     appName: 'insight',
     description: 'Find thousands of commercial property transaction comps',
-    productionUrl: 'https://app.edozo.com/',
-    stageUrl: 'https://stage-rails.edozo.co/search',
+    url: 'https://insight.edozo.com/',
   },
   {
     appName: 'reports',
     description: 'Create automated valuation reports',
-    productionUrl: 'https://reports.edozo.com/',
-    stageUrl: 'https://reports.edozo.co/',
+    url: 'https://reports.edozo.com/',
   },
 ];
 
@@ -57,16 +52,14 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 }) => (
   <Header appName={appName}>
     {logoSection}
-    {isAuthenticated && (
-      <Menu>
-        {children}
-        <Menu.PlatformMenu>
-          <ProductSwitch edozoProducts={edozoProducts} appName={appName} />
-          <Menu.PlatformButton onClick={logout} data-testid="logoutButton">
-            <LogoutIcon size="small" />
-          </Menu.PlatformButton>
-        </Menu.PlatformMenu>
-      </Menu>
-    )}
+    <Menu>
+      {isAuthenticated && children}
+      <Menu.PlatformMenu>
+        <ProductSwitch edozoProducts={edozoProducts} appName={appName} />
+        <Menu.PlatformButton onClick={logout} data-testid="logoutButton">
+          <LogoutIcon size="small" />
+        </Menu.PlatformButton>
+      </Menu.PlatformMenu>
+    </Menu>
   </Header>
 );

--- a/src/Header/AppHeader.tsx
+++ b/src/Header/AppHeader.tsx
@@ -52,14 +52,16 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 }) => (
   <Header appName={appName}>
     {logoSection}
-    <Menu>
-      {isAuthenticated && children}
-      <Menu.PlatformMenu>
-        <ProductSwitch edozoProducts={edozoProducts} appName={appName} />
-        <Menu.PlatformButton onClick={logout} data-testid="logoutButton">
-          <LogoutIcon size="small" />
-        </Menu.PlatformButton>
-      </Menu.PlatformMenu>
-    </Menu>
+    {isAuthenticated && (
+      <Menu>
+        {children}
+        <Menu.PlatformMenu>
+          <ProductSwitch edozoProducts={edozoProducts} appName={appName} />
+          <Menu.PlatformButton onClick={logout} data-testid="logoutButton">
+            <LogoutIcon size="small" />
+          </Menu.PlatformButton>
+        </Menu.PlatformMenu>
+      </Menu>
+    )}
   </Header>
 );

--- a/src/Header/ProductSwitch/ProductSwitch.tsx
+++ b/src/Header/ProductSwitch/ProductSwitch.tsx
@@ -5,25 +5,31 @@ import { ItemWrapper, StyledButtonTitle, StyledButtonV2, StyledText } from './Pr
 import { List } from '../../List';
 import { Popover } from '../../Popover';
 import { EdozoLogo } from '../../EdozoLogo';
+import { AppName } from 'Header/Header';
 
-export const ProductSwitch: React.FC<any> = ({ edozoProducts, appName }) => {
+interface Props {
+  edozoProducts: ProductInfo[];
+  appName: AppName;
+}
+
+export const ProductSwitch: React.FC<Props> = ({ edozoProducts, appName }) => {
   const [platformAppPopover, setPlatformAppPopover] = useState(false);
   const showPopover = (): void => setPlatformAppPopover(true);
   const hidePopover = (): void => setPlatformAppPopover(false);
 
   const linkHandler = (product: ProductInfo): boolean | void => {
-    const { stageUrl, productionUrl } = product;
+    const { url } = product;
     const { hostname } = window.location;
     if (hostname === 'localhost') {
       // eslint-disable-next-line no-restricted-globals, no-alert
       if (confirm('You are being taken away from your local environment')) {
-        window.open(stageUrl, '_blank');
+        window.open(url, '_blank');
         return false;
       }
       return false;
     }
-    const [, , topLevelDomain] = hostname.split('.');
-    topLevelDomain === 'co' ? window.open(stageUrl, '_blank') : window.open(productionUrl, '_blank');
+
+    window.open(url, '_blank');
     hidePopover();
   };
 
@@ -39,9 +45,9 @@ export const ProductSwitch: React.FC<any> = ({ edozoProducts, appName }) => {
         content={
           <div style={{ margin: '10px 0', borderRadius: 'inherit' }}>
             <List variant="platform">
-              {edozoProducts.map((product: any) => (
+              {edozoProducts.map(product => (
                 <List.Item
-                  key={product.productionUrl}
+                  key={product.url}
                   onClick={() => linkHandler(product)}
                   disabled={product.disabled || appName === product.appName}
                 >


### PR DESCRIPTION
I was working on the `Header` within the insight project, which has it's own version of the Mechanical wombat one. 
While I was looking at the Reports project to see what I should be migrating towards, I found this coment:

```
 /**
   * TODO: Update Header to use new links constants.
   *
   * This might involve a change to the Header component in mechanical-wombat.
   * The Header in mechanical-wombat shouldn't really have about stage and prod URL's. That should be handled by the consumer app.
   *
   * So `productionUrl` and `stageUrl` should be removed from the Header component in mechanical-wombat and replaced with one property `url`, 'link`, ...etc...
   */
```

This PR migrates us over to a single prop `url`. 

I've also added a CHANGELOG.md to the project, so we can keep track of the verion changes etc. Similar to the other libraries we have.  

