### PR TITLE
Fix DOM prop warnings in DropDown list item

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,14 @@ When adding or changing components:
 
 See [`RELEASING.md`](./RELEASING.md) for the full release process, CI pipeline details, and post-merge verification steps.
 
+## Git Branch Naming Conventions
+
+- Always use `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
+- Use kebab-case (lowercase words separated by hyphens).
+- Keep names concise but descriptive (e.g., `feat/add-login-button`).
+- Include issue numbers if applicable (e.g., `fix/issue-123-header-styling`).
+- Prompt me to give a name if you're not sure.
+
 ## Git Workflow
 
 - Branch naming: `feature/<description>` or `fix/<description>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,15 +237,14 @@ See [`RELEASING.md`](./RELEASING.md) for the full release process, CI pipeline d
 
 ## Git Branch Naming Conventions
 
-- Always use `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
+- Always use `feature/`, `fix/`, `chore/`, or `docs/` prefixes.
 - Use kebab-case (lowercase words separated by hyphens).
-- Keep names concise but descriptive (e.g., `feat/add-login-button`).
+- Keep names concise but descriptive (e.g., `feature/add-login-button`).
 - Include issue numbers if applicable (e.g., `fix/issue-123-header-styling`).
 - Prompt me to give a name if you're not sure.
 
 ## Git Workflow
 
-- Branch naming: `feature/<description>` or `fix/<description>`
 - Commit messages: imperative and descriptive (`Add Tooltip component`, not `added stuff`)
 - Open PRs against `main`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.1] - 2026-03-30
+
+### Fixed
+
+- Fixed React 18.3 DOM prop warnings in `DropDown`: renamed `highlighted` and `selectedItem` styled-component props to transient `$highlighted` / `$selectedItem` to prevent forwarding to the DOM, and extracted `key` from the `getItemProps` spread to pass it directly to JSX.
+
 ## [7.0.0] - 2026-03-16
 
 ### Removed
@@ -246,6 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `AppHeader` now accepts only a `url` prop instead of both `stageUrl` and `prodUrl`. Consumers must derive the correct URL in their own apps.
 
 [unreleased]: https://github.com/edozo/mechanical-wombat/compare/v7.0.0...HEAD
+[7.0.1]: https://github.com/edozo/mechanical-wombat/compare/v7.0.0...v7.0.1
 [7.0.0]: https://github.com/edozo/mechanical-wombat/compare/v6.0.6...v7.0.0
 [6.0.6]: https://github.com/edozo/mechanical-wombat/compare/v6.0.5...v6.0.6
 [6.0.5]: https://github.com/edozo/mechanical-wombat/compare/v6.0.4...v6.0.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edozo/mechanical-wombat",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",

--- a/src/DropDown/DropDown.styles.ts
+++ b/src/DropDown/DropDown.styles.ts
@@ -2,8 +2,8 @@ import styled, { css } from 'styled-components';
 
 export interface StyleProps {
   $isOpen?: boolean;
-  highlighted?: boolean;
-  selectedItem?: boolean;
+  $highlighted?: boolean;
+  $selectedItem?: boolean;
   $disabled?: boolean;
   $size?: 'small' | 'standard';
 }
@@ -91,15 +91,15 @@ export const StyledListItem = styled.li<StyleProps>`
       pointer-events: none;
     `};
 
-  ${({ theme, highlighted, $disabled }) =>
-    highlighted &&
+  ${({ theme, $highlighted, $disabled }) =>
+    $highlighted &&
     !$disabled &&
     css`
       background: ${theme.colors.grayLighter};
     `};
 
-  ${({ theme, selectedItem, $disabled }) =>
-    selectedItem &&
+  ${({ theme, $selectedItem, $disabled }) =>
+    $selectedItem &&
     !$disabled &&
     css`
       background: ${theme.colors.gray};

--- a/src/DropDown/DropDown.tsx
+++ b/src/DropDown/DropDown.tsx
@@ -82,13 +82,13 @@ export const DropDown: React.FC<Props> = (props) => {
                 {isOpen &&
                   props.items.map((item: DropDownItem, index: number) => (
                     <StyledListItem
+                      key={item.value}
                       $size={size}
-                      highlighted={highlightedIndex !== undefined && index === highlightedIndex}
-                      selectedItem={item.value === selectedItem?.value}
+                      $highlighted={highlightedIndex !== undefined && index === highlightedIndex}
+                      $selectedItem={item.value === selectedItem?.value}
                       $disabled={!!item.disabled}
                       {...getItemProps({
                         item,
-                        key: item.value,
                         disabled: item.disabled,
                       })}
                     >


### PR DESCRIPTION
## Summary

- Rename `highlighted` and `selectedItem` props on `StyledListItem` to transient `$highlighted` / `$selectedItem` to stop styled-components forwarding them to the DOM `<li>` element
- Extract `key` from the `getItemProps` spread and pass it directly to JSX, fixing the React 19 key-in-spread warning

## Test plan

- [x] Open the DropDown story in Storybook — browser console should show no `unknown prop` or key warnings
- [x] `yarn lint` passes with zero errors
- [x] `yarn tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I added the following to the AGENTS.md file to get a better branch name, happy to commit it or not 🤷‍♀️:

```
## Git Branch Naming Conventions

- Always use `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
- Use kebab-case (lowercase words separated by hyphens).
- Keep names concise but descriptive (e.g., `feat/add-login-button`).
- Include issue numbers if applicable (e.g., `fix/issue-123-header-styling`).
- Prompt me to give a name if you're not sure.
```