### PR TITLE
Add CI check to enforce version bump and CHANGELOG update on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,9 +135,13 @@ workflows:
             branches:
               ignore: main
       - build-and-test:
+          requires:
+            - check-release-files
           context:
             - GithubPackages
       - test-storybook:
+          requires:
+            - check-release-files
           context:
             - GithubPackages
       - publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,47 @@ jobs:
             git remote set-url origin https://$GH_PACKAGE_WRITE@github.com/edozo/mechanical-wombat.git
             yarn gh-pages -d storybook-static -b gh-pages
 
+  check-release-files:
+    docker:
+      - image: cimg/node:24.14
+    steps:
+      - checkout
+
+      - run:
+          name: Fetch main branch
+          command: git fetch origin main
+
+      - run:
+          name: Check version bump and CHANGELOG update
+          command: |
+            CHANGED=$(git diff --name-only origin/main...HEAD)
+            FAILED=""
+
+            if ! echo "$CHANGED" | grep -qx "package.json"; then
+              echo "ERROR: package.json has not been modified. Bump the version before merging."
+              FAILED=1
+            else
+              echo "OK: package.json modified."
+            fi
+
+            if ! echo "$CHANGED" | grep -qx "CHANGELOG.md"; then
+              echo "ERROR: CHANGELOG.md has not been modified. Add a changelog entry before merging."
+              FAILED=1
+            else
+              echo "OK: CHANGELOG.md modified."
+            fi
+
+            if [ -n "$FAILED" ]; then
+              exit 1
+            fi
+
 workflows:
   build_and_deploy:
     jobs:
+      - check-release-files:
+          filters:
+            branches:
+              ignore: main
       - build-and-test:
           context:
             - GithubPackages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.2] - 2026-03-31
+
+### Changed
+
+- Added a `check-release-files` CircleCI job that fails if `package.json` or `CHANGELOG.md` are not modified on a PR branch, enforcing version bumps and changelog entries before merge.
+
 ## [7.0.1] - 2026-03-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edozo/mechanical-wombat",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "React UI component lib for edozo apps and sites",
   "author": "edozo",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Adds a `check-release-files` CircleCI job that diffs the PR branch against `main` and fails if either `package.json` or `CHANGELOG.md` has not been modified
- Runs on all branches except `main` (no point checking after merge)
- Both checks run before failing so all missing files are reported at once

## Why

My main aim is to enforce version updates before a branch get's to main as it's a pain to fix it if we forget (and I have missed it a few times). I feel it is better to catch this on a branch rather than main.

## Test plan

- [x] Merge this PR without updating `package.json` or `CHANGELOG.md` — `check-release-files` should fail on a subsequent PR that omits them
- [x] Open a PR that modifies both files — job should pass
- [x] Confirm the job is skipped on `main`

<img width="2744" height="856" alt="Screenshot 2026-03-31 at 10 31 44" src="https://github.com/user-attachments/assets/64b3f7e2-b1fb-47d4-9063-eb6996ae8d7d" />

In the screenshot:

- First build attempt: nove version change of changelog change
- Second is a package version change but no changelog update
- Third is the changelog updated
- Fourth is deferring the other jobs until the version and changelog are verified to be changed.